### PR TITLE
Fixes to make the module compatible with the latest Magento version and avoid issues with other vendors.

### DIFF
--- a/Model/Template/Processor.php
+++ b/Model/Template/Processor.php
@@ -105,7 +105,6 @@ class Processor extends Template
         $isDesignApplied = $this->applyDesignConfig();
 
         $processor = $this->getTemplateFilter()
-            ->setUseSessionInUrl(false)
             ->setPlainTemplateMode($this->isPlain())
             ->setIsChildTemplate($this->isChildTemplate())
             ->setTemplateProcessor([$this, 'getTemplateContent']);

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -63,6 +63,27 @@ class UpgradeData implements UpgradeDataInterface
             $quoteInstaller->addAttribute('quote', 'mp_share_cart_token', ['type' => 'text']);
         }
 
+        if (version_compare($context->getVersion(), '1.0.2') < 0) {
+            $setup->getConnection()->changeColumn(
+                $setup->getTable('quote'),
+                'mp_share_cart_token',
+                'mp_share_cart_token',
+                [
+                    'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                    'length' => 255
+                ]
+            );
+
+            $setup->getConnection()->addIndex(
+                $setup->getTable('quote'),
+                $setup->getConnection()->getIndexName(
+                    $setup->getTable('quote'),
+                    'mp_share_cart_token'
+                ),
+                ['mp_share_cart_token']
+            );
+        }
+
         $setup->endSetup();
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "magento2-module",
   "require": {
     "mageplaza/module-core": "^1.4.5",
-    "mpdf/mpdf": "^7.1.0"
+    "mpdf/mpdf": "^7.1.0 | ^8.0.0"
   },
   "version": "1.1.1",
   "license": "proprietary",

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -21,7 +21,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mageplaza_ShareCart" setup_version="1.0.1">
+    <module name="Mageplaza_ShareCart" setup_version="1.0.2">
         <sequence>
             <module name="Mageplaza_Core"/>
             <module name="Magento_Checkout"/>


### PR DESCRIPTION
The mpdf is a mayor version behind and was causing issues with other vendors that were using the 8.* version. I have checked if we could use the 8.* and didn't face any issues and was able to download the PDF.

I also removed the setUseSessionInUrl() since the method triggers a deprecation error and contains no logic anymore in newer Magento versions.

I've also changed the mp_share_cart_token column to varchar(255) and placed an index on the column.