### PR TITLE
Fix Issue #25: Error when product have required options

### DIFF
--- a/Model/ShareCartRepository.php
+++ b/Model/ShareCartRepository.php
@@ -123,14 +123,8 @@ class ShareCartRepository implements ShareCartRepositoryInterface
                     $options     = $item->getProduct()->getTypeInstance(true)
                         ->getOrderOptions($item->getProduct());
                     $info        = $options['info_buyRequest'];
-                    $productType = $item->getProductType();
-                    $info['qty'] = $item->getQty();
-
-                    if ($productType === 'configurable' || $productType === 'bundle') {
-                        $this->cart->addProduct($product, $info);
-                    } else {
-                        $this->cart->addProduct($item->getProduct(), $info);
-                    }
+                    $info["qty"] = $item->getQty();
+                    $this->cart->addProduct($product, $info);
                 } catch (NoSuchEntityException $e) {
                     throw new LocalizedException(__('Can not add product to cart'));
                 }


### PR DESCRIPTION
At #25 I detected that when any product of a shared cart have required options, a error is thrown.

I changed the logic of the share method to add $qty to the $info_buyRequest object and add a product  with his quantity